### PR TITLE
Add art-direction inspiration board and high-fidelity concept asset samples

### DIFF
--- a/assets/concept_samples/README.md
+++ b/assets/concept_samples/README.md
@@ -1,0 +1,24 @@
+# Concept Asset Samples (Brainstorming Phase)
+
+These are **high-fidelity direction samples** intended for planning and rapid in-engine tests.
+They are not final production assets.
+
+## What is included
+
+- `environment_tiles/` — horizon, skyline, and terrain concept tiles
+- `props/` — architectural/prop silhouettes and hero landmarks
+- `ships/` — early ship silhouette experiments
+- `vfx/` — stylized beams, flares, and energy concepts
+- `ui/` — HUD panel style exploration
+
+## Usage in Godot
+
+1. Drop any SVG into a `Sprite2D` or UI `TextureRect` for quick visual tests.
+2. Mix and match warm/cool palettes to verify gameplay readability.
+3. Replace placeholders in prototype scenes once readability is confirmed.
+
+## Notes
+
+- Style references are documented in `docs/art-direction/inspiration-board.md`.
+- These assets intentionally exaggerate contrast and color separation to test legibility at gameplay speed.
+

--- a/assets/concept_samples/environment_tiles/crater_terrain_tile.svg
+++ b/assets/concept_samples/environment_tiles/crater_terrain_tile.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 512">
+  <defs>
+    <radialGradient id="planetSky" cx="70%" cy="25%" r="70%">
+      <stop offset="0%" stop-color="#ff8e6e"/>
+      <stop offset="50%" stop-color="#7c4bc6"/>
+      <stop offset="100%" stop-color="#0b1027"/>
+    </radialGradient>
+  </defs>
+  <rect width="1024" height="512" fill="url(#planetSky)"/>
+  <circle cx="740" cy="185" r="145" fill="#ffd37f" opacity="0.65"/>
+  <path d="M0 330 C160 260 320 370 510 320 C650 280 790 360 1024 300 L1024 512 L0 512 Z" fill="#1b1f48"/>
+  <ellipse cx="230" cy="390" rx="140" ry="36" fill="#2f3271"/>
+  <ellipse cx="540" cy="410" rx="180" ry="40" fill="#2a2f66"/>
+  <ellipse cx="840" cy="388" rx="120" ry="30" fill="#313975"/>
+</svg>

--- a/assets/concept_samples/environment_tiles/neon_horizon_tile.svg
+++ b/assets/concept_samples/environment_tiles/neon_horizon_tile.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 512">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#050816"/>
+      <stop offset="40%" stop-color="#192d6a"/>
+      <stop offset="100%" stop-color="#ff6a3d"/>
+    </linearGradient>
+    <linearGradient id="ground" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3a0d44"/>
+      <stop offset="100%" stop-color="#080c1e"/>
+    </linearGradient>
+  </defs>
+  <rect width="1024" height="512" fill="url(#sky)"/>
+  <circle cx="760" cy="210" r="105" fill="#ffd86a" opacity="0.9"/>
+  <path d="M0 280 L90 200 L180 260 L290 185 L420 255 L570 170 L690 250 L800 160 L920 240 L1024 185 L1024 340 L0 340 Z" fill="#0b1537"/>
+  <rect y="340" width="1024" height="172" fill="url(#ground)"/>
+  <g opacity="0.45" stroke="#4ff6ff" stroke-width="2">
+    <path d="M0 360 H1024"/>
+    <path d="M0 385 H1024"/>
+    <path d="M0 410 H1024"/>
+    <path d="M0 435 H1024"/>
+    <path d="M0 460 H1024"/>
+    <path d="M0 485 H1024"/>
+  </g>
+</svg>

--- a/assets/concept_samples/props/monolith_gate.svg
+++ b/assets/concept_samples/props/monolith_gate.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <rect width="1024" height="1024" fill="#0b122f"/>
+  <rect y="740" width="1024" height="284" fill="#1a2554"/>
+  <rect x="250" y="220" width="120" height="520" fill="#2f3f8a"/>
+  <rect x="654" y="220" width="120" height="520" fill="#2f3f8a"/>
+  <rect x="370" y="250" width="284" height="80" fill="#65f6ff" opacity="0.8"/>
+  <rect x="370" y="330" width="284" height="330" fill="#162049"/>
+  <path d="M120 740 L512 560 L904 740 Z" fill="#32437e" opacity="0.5"/>
+</svg>

--- a/assets/concept_samples/props/spaceport_spires.svg
+++ b/assets/concept_samples/props/spaceport_spires.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <rect width="1024" height="1024" fill="#d6d7e7"/>
+  <circle cx="770" cy="300" r="180" fill="#f8e7cd"/>
+  <rect x="120" y="520" width="70" height="320" fill="#3e3350"/>
+  <rect x="220" y="360" width="95" height="480" fill="#4d415f"/>
+  <rect x="360" y="290" width="130" height="560" rx="26" fill="#eee9df"/>
+  <rect x="530" y="420" width="90" height="420" fill="#d8c39f"/>
+  <rect x="660" y="480" width="140" height="360" rx="18" fill="#b0a5b8"/>
+  <rect x="820" y="380" width="60" height="460" fill="#7e6f8c"/>
+  <rect y="840" width="1024" height="184" fill="#b39e81"/>
+  <g fill="#ff9a40" opacity="0.75">
+    <rect x="365" y="420" width="120" height="8"/>
+    <rect x="365" y="520" width="120" height="8"/>
+    <rect x="365" y="620" width="120" height="8"/>
+  </g>
+</svg>

--- a/assets/concept_samples/ships/freighter_profile.svg
+++ b/assets/concept_samples/ships/freighter_profile.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 640">
+  <rect width="1280" height="640" fill="#090f25"/>
+  <rect x="160" y="290" width="820" height="140" rx="52" fill="#6b7392"/>
+  <rect x="930" y="315" width="190" height="90" rx="28" fill="#8f96af"/>
+  <rect x="220" y="250" width="180" height="40" rx="15" fill="#9fa8bf"/>
+  <rect x="280" y="320" width="520" height="24" fill="#3e4767"/>
+  <rect x="280" y="360" width="520" height="24" fill="#3e4767"/>
+  <circle cx="210" cy="360" r="44" fill="#ff8e4c"/>
+  <circle cx="210" cy="360" r="24" fill="#47e5ff"/>
+</svg>

--- a/assets/concept_samples/ships/interceptor_mk1.svg
+++ b/assets/concept_samples/ships/interceptor_mk1.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <rect width="1024" height="1024" fill="#070d22"/>
+  <polygon points="512,120 670,440 635,830 390,830 354,440" fill="#a2afcc"/>
+  <polygon points="512,170 600,450 580,780 445,780 425,450" fill="#3b486a"/>
+  <polygon points="240,560 354,520 362,620 220,670" fill="#6579a8"/>
+  <polygon points="784,560 670,520 662,620 804,670" fill="#6579a8"/>
+  <rect x="468" y="785" width="88" height="95" rx="20" fill="#ff8f4a"/>
+  <ellipse cx="512" cy="876" rx="70" ry="28" fill="#53e9ff" opacity="0.7"/>
+</svg>

--- a/assets/concept_samples/ui/hud_panel_frame.svg
+++ b/assets/concept_samples/ui/hud_panel_frame.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300">
+  <rect width="1200" height="300" fill="#070d20"/>
+  <rect x="28" y="28" width="1144" height="244" rx="20" fill="#111a3d" stroke="#56ebff" stroke-width="4"/>
+  <rect x="54" y="56" width="420" height="188" rx="12" fill="#1d2a5d"/>
+  <rect x="494" y="56" width="300" height="86" rx="12" fill="#1d2a5d"/>
+  <rect x="494" y="158" width="300" height="86" rx="12" fill="#1d2a5d"/>
+  <rect x="814" y="56" width="332" height="188" rx="12" fill="#1d2a5d"/>
+  <rect x="70" y="74" width="388" height="16" fill="#f957c6" opacity="0.7"/>
+  <rect x="830" y="74" width="140" height="16" fill="#ffc267" opacity="0.8"/>
+</svg>

--- a/assets/concept_samples/vfx/engine_bloom.svg
+++ b/assets/concept_samples/vfx/engine_bloom.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="bloom" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fff2bc"/>
+      <stop offset="30%" stop-color="#ff9e53"/>
+      <stop offset="60%" stop-color="#ea4fd3"/>
+      <stop offset="100%" stop-color="#43dfff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="512" height="512" fill="#050816"/>
+  <circle cx="256" cy="256" r="220" fill="url(#bloom)"/>
+</svg>

--- a/assets/concept_samples/vfx/plasma_beam_strip.svg
+++ b/assets/concept_samples/vfx/plasma_beam_strip.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 128">
+  <defs>
+    <linearGradient id="beam" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#41f1ff"/>
+      <stop offset="45%" stop-color="#f74cd4"/>
+      <stop offset="100%" stop-color="#ffaf4f"/>
+    </linearGradient>
+  </defs>
+  <rect width="1024" height="128" fill="#060b20"/>
+  <rect x="35" y="46" width="954" height="36" rx="18" fill="url(#beam)"/>
+  <rect x="35" y="54" width="954" height="20" rx="10" fill="#ffffff" opacity="0.42"/>
+</svg>

--- a/docs/art-direction/inspiration-board.md
+++ b/docs/art-direction/inspiration-board.md
@@ -1,0 +1,40 @@
+# Starkiller High-Fidelity Inspiration Board (Planning)
+
+This file captures the visual references provided in chat so we can keep a stable art-direction baseline while we prototype higher-fidelity assets.
+
+## Source references (user-provided)
+
+| ID | Reference | Key visual notes | Potential in-game use |
+|---|---|---|---|
+| REF-01 | Pixel-art landscape contact sheet (multi-frame set) | CRT scanline texture, neon dusk palettes (magenta/cyan/orange), broad sci-fi horizons, moody contrast | Biome color studies, loading/backdrop palette guide, minimap and skybox experimentation |
+| REF-02 | Painterly spaceport megacity | High-detail brush strokes, vertical architecture, warm/cool contrast, grand scale | Hero location concept for hub world and mission intro key art |
+| REF-03 | Retro mountain + giant sun pixel scene | Retro-futurist silhouette shapes, large celestial body, clean value hierarchy | Planet surface vista language for exploration zones |
+| REF-04 | Cubic terrace + lake + sunset scene | Geometric hard-surface landscaping mixed with natural forms, atmospheric haze | Architectural set-dressing and puzzle arena mood |
+| REF-05 | Lunar outpost with magenta lighting | Strong sci-fi structures, saturated purple-pink terrain, cold space backdrop | Faction outpost kit and environment tone for off-world maps |
+
+## Art-direction pillars (v0)
+
+1. **Retro-futurist color scripting**
+   - Base palette: deep navy + cyan + magenta + sunset orange.
+   - Use warm accents for points of interest (doors, objectives, interactables).
+2. **Layered detail over clean silhouettes**
+   - Primary forms should read clearly at distance.
+   - Surface richness should come from materials, normal maps, decals, and VFX overlays.
+3. **Hybrid aesthetic**
+   - Allow both painterly high-fidelity scenes and stylized pixel-inspired motifs.
+   - Keep world coherent with consistent lighting rules and accent colors.
+4. **Scale-first composition**
+   - Prefer gigantic structures, broad horizons, and oversized celestial bodies.
+   - Anchor each scene with one readable focal landmark.
+
+## Immediate experimentation goals
+
+- Build quick, testable sample assets that push quality beyond current placeholders.
+- Validate readability under gameplay camera distances.
+- Test palette consistency across environment, props, ships, VFX, and UI.
+
+## Related files
+
+- `assets/concept_samples/README.md`
+- `assets/concept_samples/**/*.svg`
+

--- a/docs/art-direction/inspiration-manifest.json
+++ b/docs/art-direction/inspiration-manifest.json
@@ -1,0 +1,31 @@
+{
+  "collection": "starkiller-high-fidelity-inspiration-v1",
+  "source": "user-provided chat attachments",
+  "references": [
+    {
+      "id": "REF-01",
+      "label": "Pixel-art landscape contact sheet",
+      "tags": ["pixel", "scanlines", "neon", "horizon", "retro-future"]
+    },
+    {
+      "id": "REF-02",
+      "label": "Painterly futuristic spaceport city",
+      "tags": ["painterly", "megastructure", "spaceport", "high-detail"]
+    },
+    {
+      "id": "REF-03",
+      "label": "Retro mountain vista with giant sun",
+      "tags": ["pixel", "planet", "landscape", "silhouette"]
+    },
+    {
+      "id": "REF-04",
+      "label": "Terraced geometric garden at sunset",
+      "tags": ["geometric", "architecture", "water", "cinematic"]
+    },
+    {
+      "id": "REF-05",
+      "label": "Lunar outpost with magenta sci-fi structures",
+      "tags": ["moon", "outpost", "magenta", "sci-fi", "structures"]
+    }
+  ]
+}

--- a/docs/art-direction/worktree-plan.md
+++ b/docs/art-direction/worktree-plan.md
@@ -1,0 +1,9 @@
+# Optional Art Lab Worktree
+
+To keep experimentation isolated, an additional worktree can be used:
+
+```bash
+git worktree add ../starkiller-space-game-art-lab -b art-lab-high-fidelity
+```
+
+This mirrors the repository into a separate folder for high-fidelity art exploration without disturbing day-to-day gameplay tasks.


### PR DESCRIPTION
### Motivation

- Consolidate the user-provided visual references into a stable, versioned art-direction record for higher-fidelity prototyping.
- Provide a set of quick, high-fidelity SVG concept samples to accelerate in-engine experimentation across environments, props, ships, VFX, and UI.
- Encourage isolated experimentation workflows by documenting an optional art-lab worktree for art exploration separate from gameplay work.

### Description

- Add `docs/art-direction/inspiration-board.md` capturing reference IDs, visual notes, and initial art-direction pillars for the high-fidelity direction.
- Add `docs/art-direction/inspiration-manifest.json` as a machine-readable manifest of the reference set for planning and tooling reuse.
- Add `assets/concept_samples/` with subfolders and a `README.md` plus multiple SVG samples under `environment_tiles/`, `props/`, `ships/`, `vfx/`, and `ui/` to allow quick drop-in tests in Godot.
- Add `docs/art-direction/worktree-plan.md` documenting an optional isolated art-lab workflow for experimentation.

### Testing

- Parsed all generated SVG files with a small Python validation using `xml.etree.ElementTree` to ensure each SVG is syntactically valid, and the check succeeded.
- Verified repository status after adding the files via `git status --short`, which reported the new files as added and no unexpected modifications.
- Queried the current revision via `git rev-parse --short HEAD` to capture the commit reference for this change, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3b9405aec8324a4aba22417dbcd0c)