### PR TITLE
Session 8 kickoff: resource-driven stage segments + regression coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Current coverage includes both unit checks and scenario flows for `GameState`:
   - collectible fuel tanks spawned by stage segment rules.
 - Stage progression shell:
   - distance-based segment transitions,
-  - segment-specific spawn parameters,
+  - segment-specific spawn parameters loaded from resource data (`assets/data/stage_segments.tres`),
   - HUD stage/segment visibility.
 - Prototype input remapping panel for core actions (`move_*`, `fire`, `bomb`, `start`, `pause`) with local persistence.
 - Bombs can damage both ground and air enemies (direct hit and blast radius on terrain impact).
@@ -63,7 +63,7 @@ Run automated Session 5 smoke checks:
 ## Notes
 
 - Core visuals are still placeholder-driven, but Session 6 added baseline sprite/VFX/SFX readability improvements.
-- Session 7 regression-hardening closeout is complete; Session 8 kickoff will focus on deferred manual validation and terrain/stage-data upgrades.
+- Session 7 regression-hardening closeout is complete; Session 8 work is now active for stage-data externalization and deferred manual validation kickoff.
 
 ## Copilot / AI helpers
 
@@ -76,5 +76,5 @@ Project documentation now follows a project-scoped docs convention:
 - Docs index: `docs/README.md`
 - Project docs entrypoint: `docs/project-starkiller-prototype/README.md`
 - Canonical spec: `docs/project-starkiller-prototype/2026-02-28-spec-starkiller-prototype-v1.md`
-- Latest tasks file: `docs/project-starkiller-prototype/2026-03-01-tasks-session-07-regression-hardening.md` (Session 7 closeout)
+- Latest tasks file: `docs/project-starkiller-prototype/2026-03-01-tasks-session-08-stage-data-and-validation-kickoff.md` (active Session 8 tracker)
 - Historical roadmap archive: `docs/project-starkiller-prototype/2026-02-28-tasks-session-01-05-roadmap.md`

--- a/assets/data/stage_segments.tres
+++ b/assets/data/stage_segments.tres
@@ -1,0 +1,43 @@
+[gd_resource type="Resource" script_class="StageSegmentSettings" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/stage_segment_settings.gd" id="1_qxj4r"]
+
+[resource]
+script = ExtResource("1_qxj4r")
+segments = [{
+"air_speed_max": 185.0,
+"air_speed_min": 120.0,
+"enemy_spawn_interval": 1.15,
+"enemy_spawn_variance": 0.2,
+"fuel_tank_amount": 24.0,
+"fuel_tank_interval": 7.0,
+"ground_speed_max": 125.0,
+"ground_speed_min": 90.0,
+"ground_target_chance": 0.3,
+"length_px": 2400.0,
+"segment_name": "Sector 1: Open Sky"
+}, {
+"air_speed_max": 205.0,
+"air_speed_min": 135.0,
+"enemy_spawn_interval": 0.95,
+"enemy_spawn_variance": 0.22,
+"fuel_tank_amount": 22.0,
+"fuel_tank_interval": 5.5,
+"ground_speed_max": 140.0,
+"ground_speed_min": 100.0,
+"ground_target_chance": 0.45,
+"length_px": 2600.0,
+"segment_name": "Sector 2: Canyon"
+}, {
+"air_speed_max": 220.0,
+"air_speed_min": 150.0,
+"enemy_spawn_interval": 0.82,
+"enemy_spawn_variance": 0.18,
+"fuel_tank_amount": 20.0,
+"fuel_tank_interval": 4.8,
+"ground_speed_max": 150.0,
+"ground_speed_min": 110.0,
+"ground_target_chance": 0.55,
+"length_px": 3000.0,
+"segment_name": "Sector 3: Fortress Run"
+}]

--- a/docs/project-starkiller-prototype/2026-02-28-spec-starkiller-prototype-v1.md
+++ b/docs/project-starkiller-prototype/2026-02-28-spec-starkiller-prototype-v1.md
@@ -46,7 +46,7 @@
 
 ## Session Notes (2026-03-01)
 
-### Implemented (Sessions 1-6)
+### Implemented (Sessions 1-8, current)
 - Godot project scaffold with startup scene (`scenes/Main.tscn`) and Godot 4.6.1 compatibility fixes.
 - Required keyboard input actions with defaults: arrows, `Z`, `X`, `Enter`, `Esc`.
 - Prototype `refuel` action on `R` retained for quick fuel-loop validation.
@@ -83,6 +83,10 @@
 - Session 7 regression closeout:
   - explicit startup window-mode default (`display/window/size/mode=0`, windowed),
   - regression checks rerun and kept green.
+- Session 8 foundation (in progress):
+  - stage segment data externalized to `assets/data/stage_segments.tres`,
+  - resource-driven loading with fallback defaults in `scripts/main.gd`,
+  - regression coverage expanded for segment settings normalization/fallback.
 
 ### Confirmed behavior in current prototype
 - Multi-input combinations are visible through on-screen pressed-action debug text.
@@ -94,16 +98,15 @@
 - Remapped controls persist across restarts.
 - Bombs can damage flying enemies via direct contact and terrain-impact blast radius.
 - Headless checks currently pass:
-  - `tests/run_tests.gd` (8 passed, 0 failed),
+  - `tests/run_tests.gd` (10 passed, 0 failed),
   - `scripts/smoke_test.gd` (pass).
 
 ### Open assumptions and active gaps (Post-Session 7)
 - Terrain geometry and terrain collision are still placeholder-driven.
-- Stage segments are data-driven but currently script-local (not externalized resources yet).
 - Art direction baseline is established, but production-quality asset pipeline decisions are not finalized.
 - Human validation backlog (pacing/usability/bug-bash triage) is explicitly deferred to Session 8 kickoff manual playtesting.
 
-### Active next phase (Session 8 planning)
-- Externalize stage segment definitions from `main.gd` into project resources.
+### Active next phase (Session 8 execution)
+- Run deferred manual validation backlog at Session 8 kickoff and prioritize resulting defects.
 - Begin replacing placeholder-driven terrain behavior with more explicit data/geometry rules.
-- Run deferred manual validation backlog at Session 8 kickoff and prioritize any resulting defects.
+- Continue hardening resource-driven stage data flow and supporting tests.

--- a/docs/project-starkiller-prototype/2026-02-28-tasks-session-05-regression-checklist.md
+++ b/docs/project-starkiller-prototype/2026-02-28-tasks-session-05-regression-checklist.md
@@ -19,6 +19,7 @@ Covers:
 - Required input actions exist in `InputMap`.
 - `GameState` start/pause/death/respawn transitions.
 - Enemy hit rules: laser vs air, bomb vs ground, bomb vs air.
+- Stage segment resource exists and returns a non-empty normalized segment list.
 
 ## Manual Gameplay Checks
 

--- a/docs/project-starkiller-prototype/2026-03-01-tasks-session-08-stage-data-and-validation-kickoff.md
+++ b/docs/project-starkiller-prototype/2026-03-01-tasks-session-08-stage-data-and-validation-kickoff.md
@@ -1,0 +1,52 @@
+# Session 8 Tasks - Stage Data + Validation Kickoff
+
+Date: 2026-03-01
+Source: Session 7 closeout handoff + Session 8 planning goals.
+
+## Goal
+
+Start Session 8 by externalizing stage segment data from gameplay code and kicking off deferred manual validation work.
+
+## Scope (Session 8)
+
+1. `AI Agent` - Externalize stage segment definitions
+- Move segment values out of `scripts/main.gd` and into a dedicated resource file.
+- Keep runtime behavior stable with a fallback path if resource data is missing/invalid.
+
+2. `AI Agent` - Add regression coverage for stage data plumbing
+- Add tests for stage segment default fallback and normalization behavior.
+- Keep all existing automated checks green.
+
+3. `Human` - Run deferred manual validation kickoff
+- Playtest progression pacing and difficulty spikes.
+- Validate pause/menu/remap usability preferences.
+- Run focused bug bash and prioritize issues.
+
+4. `AI Agent` - Apply top-priority Session 8 fixes
+- Address high-impact defects found by manual validation.
+- Keep scope on stability and data/terrain architecture work.
+
+5. `AI Agent` - Keep docs synchronized
+- Track Session 8 progress in this file.
+- Update spec and READMEs as decisions are confirmed.
+
+## Acceptance Criteria
+
+- Stage segment values are resource-driven instead of hardcoded in `main.gd`.
+- Resource-loading fallback path exists and is test-covered.
+- Automated tests and smoke checks pass after Session 8 updates.
+- Deferred human validation backlog is either completed or explicitly deferred with rationale.
+
+## Execution Checklist (Live)
+
+Last updated: 2026-03-01
+Branch: `codex/session8-stage-data`
+
+- [x] Externalize stage segment definitions to `assets/data/stage_segments.tres`.
+- [x] Load stage segments from resource with safe fallback defaults.
+- [x] Add automated tests for segment settings fallback/normalization.
+- [ ] Human playtest progression pacing and difficulty spikes.
+- [ ] Human validate pause/menu/remap usability and preference decisions.
+- [ ] Human run focused bug bash and prioritize top issues.
+- [ ] Apply top-priority fixes from Session 8 manual validation.
+- [ ] Update spec + READMEs + timeline with validation outcomes.

--- a/docs/project-starkiller-prototype/README.md
+++ b/docs/project-starkiller-prototype/README.md
@@ -4,7 +4,7 @@ This folder is the canonical documentation for the current Starkiller Space Game
 
 ## Current Status
 
-Prototype completed Session 7 regression-hardening closeout. Startup mode defaults are now explicit (windowed), automated checks are green, and manual playtest validation is queued for Session 8 kickoff.
+Session 8 is now active. Stage segment configuration has started moving from hardcoded script data into resources, and deferred manual validation is queued for kickoff playtesting.
 
 ## Timeline
 
@@ -17,6 +17,7 @@ Prototype completed Session 7 regression-hardening closeout. Startup mode defaul
 | 2026-02-28 | Tasks | `2026-02-28-tasks-session-06-upscale-fidelity.md` | Session 6 baseline upscale/fidelity execution record |
 | 2026-03-01 | Brainstorm | `2026-03-01-brainstorm-high-fidelity-visual-exploration.md` | Inspiration archive + concept asset lab setup |
 | 2026-03-01 | Tasks | `2026-03-01-tasks-session-07-regression-hardening.md` | Session 7 closeout tracker (manual validation deferred to Session 8 kickoff) |
+| 2026-03-01 | Tasks | `2026-03-01-tasks-session-08-stage-data-and-validation-kickoff.md` | Active Session 8 tracker (stage-data externalization + validation kickoff) |
 
 ## Naming Convention
 

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -28,6 +28,8 @@ const SFX_SYNTH_SCRIPT := preload("res://scripts/sfx_synth.gd")
 const PARALLAX_BACKGROUND_SCRIPT := preload("res://scripts/parallax_background.gd")
 const TERRAIN_BAND_SCRIPT := preload("res://scripts/terrain_band.gd")
 const CEILING_BAND_SCRIPT := preload("res://scripts/ceiling_band.gd")
+const STAGE_SEGMENT_SETTINGS_SCRIPT := preload("res://scripts/stage_segment_settings.gd")
+const STAGE_SEGMENTS_RESOURCE_PATH := "res://assets/data/stage_segments.tres"
 const BOMB_GROUND_BLAST_RADIUS := 92.0
 const MAJOR_SHAKE_STRENGTH := 8.0
 const MINOR_SHAKE_STRENGTH := 4.0
@@ -98,7 +100,7 @@ var screen_shake_remaining := 0.0
 func _ready() -> void:
 	rng.randomize()
 	_create_world_layers()
-	_build_stage_segments()
+	_load_stage_segments()
 	_ensure_fullscreen_input_action()
 	_load_input_bindings()
 	game_state.changed.connect(_update_hud)
@@ -572,48 +574,15 @@ func _terrain_height_at(screen_x: float) -> float:
 func _spawn_x() -> float:
 	return get_viewport_rect().size.x + SPAWN_MARGIN_X
 
-func _build_stage_segments() -> void:
-	stage_segments = [
-		{
-			"segment_name": "Sector 1: Open Sky",
-			"length_px": 2400.0,
-			"enemy_spawn_interval": 1.15,
-			"enemy_spawn_variance": 0.20,
-			"ground_target_chance": 0.30,
-			"air_speed_min": 120.0,
-			"air_speed_max": 185.0,
-			"ground_speed_min": 90.0,
-			"ground_speed_max": 125.0,
-			"fuel_tank_interval": 7.0,
-			"fuel_tank_amount": 24.0
-		},
-		{
-			"segment_name": "Sector 2: Canyon",
-			"length_px": 2600.0,
-			"enemy_spawn_interval": 0.95,
-			"enemy_spawn_variance": 0.22,
-			"ground_target_chance": 0.45,
-			"air_speed_min": 135.0,
-			"air_speed_max": 205.0,
-			"ground_speed_min": 100.0,
-			"ground_speed_max": 140.0,
-			"fuel_tank_interval": 5.5,
-			"fuel_tank_amount": 22.0
-		},
-		{
-			"segment_name": "Sector 3: Fortress Run",
-			"length_px": 3000.0,
-			"enemy_spawn_interval": 0.82,
-			"enemy_spawn_variance": 0.18,
-			"ground_target_chance": 0.55,
-			"air_speed_min": 150.0,
-			"air_speed_max": 220.0,
-			"ground_speed_min": 110.0,
-			"ground_speed_max": 150.0,
-			"fuel_tank_interval": 4.8,
-			"fuel_tank_amount": 20.0
-		}
-	]
+func _load_stage_segments() -> void:
+	stage_segments.clear()
+
+	var loaded_resource := ResourceLoader.load(STAGE_SEGMENTS_RESOURCE_PATH)
+	if loaded_resource != null and loaded_resource.has_method("normalized_segments_or_default"):
+		stage_segments = loaded_resource.call("normalized_segments_or_default")
+
+	if stage_segments.is_empty():
+		stage_segments = STAGE_SEGMENT_SETTINGS_SCRIPT.default_segments()
 
 func _reset_run_progression() -> void:
 	current_segment_index = 0
@@ -628,7 +597,7 @@ func _reset_run_progression() -> void:
 
 func _current_segment():
 	if stage_segments.is_empty():
-		_build_stage_segments()
+		_load_stage_segments()
 	return stage_segments[min(current_segment_index, stage_segments.size() - 1)]
 
 func _update_stage_progress(delta: float) -> void:

--- a/scripts/smoke_test.gd
+++ b/scripts/smoke_test.gd
@@ -2,6 +2,8 @@ extends SceneTree
 
 const GAME_STATE_SCRIPT := preload("res://scripts/game_state.gd")
 const ENEMY_TARGET_SCRIPT := preload("res://scripts/enemy_target.gd")
+const STAGE_SEGMENT_SETTINGS_SCRIPT := preload("res://scripts/stage_segment_settings.gd")
+const STAGE_SEGMENTS_RESOURCE_PATH := "res://assets/data/stage_segments.tres"
 const REQUIRED_ACTIONS: Array[String] = [
 	"move_up",
 	"move_down",
@@ -20,6 +22,7 @@ func _initialize() -> void:
 	_test_input_actions()
 	_test_game_state_transitions()
 	_test_enemy_hit_rules()
+	_test_stage_segment_resource()
 
 	if failures.is_empty():
 		print("Smoke tests passed.")
@@ -103,6 +106,23 @@ func _test_enemy_hit_rules() -> void:
 	_free_node_if_needed(ground_bomb_target)
 	_free_node_if_needed(air_laser_target)
 	_free_node_if_needed(air_bomb_target)
+
+func _test_stage_segment_resource() -> void:
+	if not _assert_script_instantiable(STAGE_SEGMENT_SETTINGS_SCRIPT, "stage_segment_settings.gd"):
+		return
+	var loaded_resource := ResourceLoader.load(STAGE_SEGMENTS_RESOURCE_PATH)
+	if loaded_resource == null:
+		failures.append("Missing stage segment resource: %s" % STAGE_SEGMENTS_RESOURCE_PATH)
+		return
+	if not loaded_resource.has_method("normalized_segments_or_default"):
+		failures.append("Stage segment resource missing normalized_segments_or_default().")
+		return
+	var segments: Variant = loaded_resource.call("normalized_segments_or_default")
+	if not (segments is Array):
+		failures.append("Stage segment resource did not return an Array.")
+		return
+	if (segments as Array).is_empty():
+		failures.append("Stage segment resource returned an empty segment list.")
 
 func _assert(condition: bool, message: String) -> void:
 	if not condition:

--- a/scripts/stage_segment_settings.gd
+++ b/scripts/stage_segment_settings.gd
@@ -1,0 +1,88 @@
+extends Resource
+class_name StageSegmentSettings
+
+const DEFAULT_SEGMENTS: Array[Dictionary] = [
+	{
+		"segment_name": "Sector 1: Open Sky",
+		"length_px": 2400.0,
+		"enemy_spawn_interval": 1.15,
+		"enemy_spawn_variance": 0.20,
+		"ground_target_chance": 0.30,
+		"air_speed_min": 120.0,
+		"air_speed_max": 185.0,
+		"ground_speed_min": 90.0,
+		"ground_speed_max": 125.0,
+		"fuel_tank_interval": 7.0,
+		"fuel_tank_amount": 24.0
+	},
+	{
+		"segment_name": "Sector 2: Canyon",
+		"length_px": 2600.0,
+		"enemy_spawn_interval": 0.95,
+		"enemy_spawn_variance": 0.22,
+		"ground_target_chance": 0.45,
+		"air_speed_min": 135.0,
+		"air_speed_max": 205.0,
+		"ground_speed_min": 100.0,
+		"ground_speed_max": 140.0,
+		"fuel_tank_interval": 5.5,
+		"fuel_tank_amount": 22.0
+	},
+	{
+		"segment_name": "Sector 3: Fortress Run",
+		"length_px": 3000.0,
+		"enemy_spawn_interval": 0.82,
+		"enemy_spawn_variance": 0.18,
+		"ground_target_chance": 0.55,
+		"air_speed_min": 150.0,
+		"air_speed_max": 220.0,
+		"ground_speed_min": 110.0,
+		"ground_speed_max": 150.0,
+		"fuel_tank_interval": 4.8,
+		"fuel_tank_amount": 20.0
+	}
+]
+
+@export var segments: Array[Dictionary] = []
+
+func normalized_segments() -> Array[Dictionary]:
+	var normalized: Array[Dictionary] = []
+	for raw_segment in segments:
+		if typeof(raw_segment) != TYPE_DICTIONARY:
+			continue
+		normalized.append(_normalize_segment(raw_segment))
+	return normalized
+
+func normalized_segments_or_default() -> Array[Dictionary]:
+	var normalized := normalized_segments()
+	if not normalized.is_empty():
+		return normalized
+	return default_segments()
+
+static func default_segments() -> Array[Dictionary]:
+	var copy: Array[Dictionary] = []
+	for segment in DEFAULT_SEGMENTS:
+		copy.append(segment.duplicate(true))
+	return copy
+
+func _normalize_segment(raw_segment: Dictionary) -> Dictionary:
+	var ground_target_chance := _to_float_or(raw_segment.get("ground_target_chance"), 0.40)
+	return {
+		"segment_name": String(raw_segment.get("segment_name", "Unnamed Sector")),
+		"length_px": maxf(_to_float_or(raw_segment.get("length_px"), 2400.0), 100.0),
+		"enemy_spawn_interval": maxf(_to_float_or(raw_segment.get("enemy_spawn_interval"), 1.0), 0.1),
+		"enemy_spawn_variance": maxf(_to_float_or(raw_segment.get("enemy_spawn_variance"), 0.2), 0.0),
+		"ground_target_chance": clampf(ground_target_chance, 0.0, 1.0),
+		"air_speed_min": maxf(_to_float_or(raw_segment.get("air_speed_min"), 120.0), 10.0),
+		"air_speed_max": maxf(_to_float_or(raw_segment.get("air_speed_max"), 180.0), 10.0),
+		"ground_speed_min": maxf(_to_float_or(raw_segment.get("ground_speed_min"), 90.0), 10.0),
+		"ground_speed_max": maxf(_to_float_or(raw_segment.get("ground_speed_max"), 130.0), 10.0),
+		"fuel_tank_interval": maxf(_to_float_or(raw_segment.get("fuel_tank_interval"), 6.0), 0.0),
+		"fuel_tank_amount": maxf(_to_float_or(raw_segment.get("fuel_tank_amount"), 20.0), 0.0)
+	}
+
+func _to_float_or(value: Variant, fallback: float) -> float:
+	var value_type := typeof(value)
+	if value_type == TYPE_FLOAT or value_type == TYPE_INT:
+		return float(value)
+	return fallback

--- a/tests/run_tests.gd
+++ b/tests/run_tests.gd
@@ -1,6 +1,7 @@
 extends SceneTree
 
 const GameStateScript := preload("res://scripts/game_state.gd")
+const StageSegmentSettingsScript := preload("res://scripts/stage_segment_settings.gd")
 
 var _passes := 0
 var _failures := 0
@@ -18,6 +19,8 @@ func _run_all() -> void:
 	_run_test("respawn triggers after cooldown when lives remain", _test_respawn_after_cooldown)
 	_run_test("game over at zero lives does not respawn", _test_game_over_at_zero_lives)
 	_run_test("fuel clamped to max", _test_fuel_clamped)
+	_run_test("stage segment settings fallback to defaults", _test_stage_segment_settings_fallback_to_defaults)
+	_run_test("stage segment settings normalize bad values", _test_stage_segment_settings_normalize_bad_values)
 	_run_test("scenario: full lifecycle to game over", _scenario_full_lifecycle_to_game_over)
 	_run_test("scenario: pause freezes fuel drain and then resumes", _scenario_pause_freeze_and_resume)
 
@@ -90,6 +93,47 @@ func _test_fuel_clamped() -> void:
 	state.start_run()
 	state.add_fuel(9999.0)
 	_expect_eq(state.fuel, state.MAX_FUEL, "fuel should not exceed max")
+
+func _test_stage_segment_settings_fallback_to_defaults() -> void:
+	var settings = StageSegmentSettingsScript.new()
+	var empty_segments: Array[Dictionary] = []
+	settings.segments = empty_segments
+	var segments: Array = settings.normalized_segments_or_default()
+	var defaults: Array = StageSegmentSettingsScript.default_segments()
+	_expect_true(not segments.is_empty(), "fallback should produce default stage segments")
+	_expect_eq(segments.size(), defaults.size(), "fallback should match default segment count")
+	_expect_eq(String(segments[0]["segment_name"]), String(defaults[0]["segment_name"]), "fallback should keep default first segment")
+
+func _test_stage_segment_settings_normalize_bad_values() -> void:
+	var settings = StageSegmentSettingsScript.new()
+	var malformed_segments: Array[Dictionary] = [{
+		"segment_name": "Stress Segment",
+		"length_px": -5.0,
+		"enemy_spawn_interval": 0.0,
+		"enemy_spawn_variance": -2.0,
+		"ground_target_chance": 3.0,
+		"air_speed_min": "invalid",
+		"air_speed_max": 5.0,
+		"ground_speed_min": -2.0,
+		"ground_speed_max": 1.0,
+		"fuel_tank_interval": -0.5,
+		"fuel_tank_amount": -8.0
+	}]
+	settings.segments = malformed_segments
+	var segments: Array = settings.normalized_segments()
+	_expect_eq(segments.size(), 1, "normalization should keep valid dictionary entries")
+	var segment: Dictionary = segments[0]
+	_expect_eq(String(segment["segment_name"]), "Stress Segment", "segment name should be preserved")
+	_expect_true(float(segment["length_px"]) >= 100.0, "length should clamp to a positive minimum")
+	_expect_true(float(segment["enemy_spawn_interval"]) >= 0.1, "spawn interval should clamp to a safe minimum")
+	_expect_true(float(segment["enemy_spawn_variance"]) >= 0.0, "spawn variance should not be negative")
+	_expect_true(float(segment["ground_target_chance"]) <= 1.0 and float(segment["ground_target_chance"]) >= 0.0, "ground chance should clamp to [0,1]")
+	_expect_true(float(segment["air_speed_min"]) >= 10.0, "air speed minimum should be sanitized")
+	_expect_true(float(segment["air_speed_max"]) >= 10.0, "air speed maximum should be sanitized")
+	_expect_true(float(segment["ground_speed_min"]) >= 10.0, "ground speed minimum should be sanitized")
+	_expect_true(float(segment["ground_speed_max"]) >= 10.0, "ground speed maximum should be sanitized")
+	_expect_eq(float(segment["fuel_tank_interval"]), 0.0, "fuel tank interval should clamp to zero minimum")
+	_expect_eq(float(segment["fuel_tank_amount"]), 0.0, "fuel amount should clamp to zero minimum")
 
 func _scenario_full_lifecycle_to_game_over() -> void:
 	var state = GameStateScript.new()


### PR DESCRIPTION
## Summary
- start Session 8 with a new active tasks tracker and docs timeline/status updates
- externalize stage segment spawn tuning from `scripts/main.gd` into `assets/data/stage_segments.tres`
- add `StageSegmentSettings` resource helper with normalization and default fallback behavior
- wire `main.gd` to load stage segments from resource with safe fallback
- extend automated checks to cover stage segment normalization/fallback and smoke-check resource loading

## Testing
- `mkdir -p /tmp/starkiller-tests && /Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/chrisbremer/code/starkiller-space-game --user-data-dir /tmp/starkiller-tests --log-file /tmp/starkiller-tests/godot.log --script res://tests/run_tests.gd`
- `mkdir -p /tmp/starkiller-smoke && /Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/chrisbremer/code/starkiller-space-game --user-data-dir /tmp/starkiller-smoke --log-file /tmp/starkiller-smoke/godot.log --script res://scripts/smoke_test.gd`
- `/Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/chrisbremer/code/starkiller-space-game --quit`