### PR TITLE
Optimize runtime loop and fix respawn freeze

### DIFF
--- a/scripts/ceiling_band.gd
+++ b/scripts/ceiling_band.gd
@@ -1,8 +1,40 @@
 extends Node2D
 
+const SEGMENT_PROFILES := [
+	{
+		"base": 0.16,
+		"amp": 18.0,
+		"fill": Color(0.14, 0.17, 0.13),
+		"line": Color(0.27, 0.35, 0.24)
+	},
+	{
+		"base": 0.17,
+		"amp": 26.0,
+		"fill": Color(0.21, 0.17, 0.12),
+		"line": Color(0.39, 0.31, 0.20)
+	},
+	{
+		"base": 0.18,
+		"amp": 34.0,
+		"fill": Color(0.17, 0.13, 0.21),
+		"line": Color(0.31, 0.24, 0.40)
+	}
+]
+
 var _scroll_distance := 0.0
 var _segment_index := 0
 var _profile_override: Dictionary = {}
+var _base_ratio := 0.16
+var _amplitude := 18.0
+var _freq_a := 0.0089
+var _freq_b := 0.019
+var _freq_c := 0.0037
+var _weight_b := 0.46
+var _weight_c := 0.80
+var _jagged := 0.0
+var _sample_step := 20.0
+var _fill_color := Color(0.14, 0.17, 0.13)
+var _line_color := Color(0.27, 0.35, 0.24)
 
 const BASE_MIN := 0.05
 const BASE_MAX := 0.40
@@ -10,98 +42,84 @@ const AMP_MIN := 4.0
 const AMP_MAX := 120.0
 
 func set_scroll_distance(distance: float) -> void:
+	if is_equal_approx(_scroll_distance, distance):
+		return
 	_scroll_distance = distance
 	queue_redraw()
 
 func set_segment_index(index: int) -> void:
-	_segment_index = max(index, 0)
+	var next_index: int = max(index, 0)
+	if _segment_index == next_index:
+		return
+	_segment_index = next_index
+	_refresh_profile_cache()
 	queue_redraw()
 
 func set_profile_override(profile: Dictionary) -> void:
-	if typeof(profile) == TYPE_DICTIONARY:
-		_profile_override = profile
-	else:
-		_profile_override = {}
+	var next_override: Dictionary = profile if typeof(profile) == TYPE_DICTIONARY else {}
+	if _profile_override == next_override:
+		return
+	_profile_override = next_override
+	_refresh_profile_cache()
 	queue_redraw()
 
 func ceiling_height_at_screen_x(screen_x: float) -> float:
 	var size := get_viewport_rect().size
-	var profile := _profile_for_segment(_segment_index)
-	var world_x := screen_x + _scroll_distance
-	var base := size.y * float(profile["base"])
-	var amp := float(profile["amp"])
-	var freq_a := float(profile.get("freq_a", 0.0089))
-	var freq_b := float(profile.get("freq_b", 0.019))
-	var freq_c := float(profile.get("freq_c", 0.0037))
-	var weight_b := float(profile.get("weight_b", 0.46))
-	var weight_c := float(profile.get("weight_c", 0.80))
-	var jagged := float(profile.get("jagged", 0.0))
-	var y := base
-	y += sin(world_x * freq_a) * amp
-	y += cos(world_x * freq_b) * amp * weight_b
-	y += sin(world_x * freq_c) * amp * weight_c
-	if jagged > 0.0:
-		y += (snapped(cos(world_x * 0.14), 0.2) * amp * 0.30 * jagged)
-	return clampf(y, 26.0, size.y * 0.42)
+	return _ceiling_height_for_world_x(screen_x + _scroll_distance, size.y)
 
 func _draw() -> void:
 	var size := get_viewport_rect().size
-	var profile := _profile_for_segment(_segment_index)
-	var fill_color: Color = profile["fill"]
-	var line_color: Color = profile["line"]
 	var points := PackedVector2Array()
 	var ridge := PackedVector2Array()
 
 	points.push_back(Vector2(0, 0))
-	var step := maxf(8.0, float(profile.get("step", 20.0)))
+	var step := _sample_step
 	var x := 0.0
 	while x <= size.x + step:
-		var y := ceiling_height_at_screen_x(x)
+		var y := _ceiling_height_for_world_x(x + _scroll_distance, size.y)
 		var point := Vector2(x, y)
 		points.push_back(point)
 		ridge.push_back(point)
 		x += step
 	points.push_back(Vector2(size.x + step, 0))
 
-	draw_colored_polygon(points, fill_color)
-	draw_polyline(ridge, line_color, 2.5)
-	_draw_ceiling_teeth(ridge, line_color)
+	draw_colored_polygon(points, _fill_color)
+	draw_polyline(ridge, _line_color, 2.5)
+	_draw_ceiling_teeth(ridge)
 
-func _draw_ceiling_teeth(ridge: PackedVector2Array, line_color: Color) -> void:
+func _draw_ceiling_teeth(ridge: PackedVector2Array) -> void:
 	if ridge.size() < 2:
 		return
-	var tooth_color := line_color.lerp(Color.WHITE, 0.08)
+	var tooth_color := _line_color.lerp(Color.WHITE, 0.08)
 	tooth_color.a = 0.34
 	for i in range(0, ridge.size(), 3):
 		var p := ridge[i]
 		var tooth_len := 11.0 + (sin((p.x + _scroll_distance) * 0.09) + 1.0) * 7.5
 		draw_line(p, p + Vector2(0, tooth_len), tooth_color, 1.0)
 
-func _profile_for_segment(index: int) -> Dictionary:
-	var profiles := [
-		{
-			"base": 0.16,
-			"amp": 18.0,
-			"fill": Color(0.14, 0.17, 0.13),
-			"line": Color(0.27, 0.35, 0.24)
-		},
-		{
-			"base": 0.17,
-			"amp": 26.0,
-			"fill": Color(0.21, 0.17, 0.12),
-			"line": Color(0.39, 0.31, 0.20)
-		},
-		{
-			"base": 0.18,
-			"amp": 34.0,
-			"fill": Color(0.17, 0.13, 0.21),
-			"line": Color(0.31, 0.24, 0.40)
-		}
-	]
-	var profile: Dictionary = profiles[min(index, profiles.size() - 1)]
-	if _profile_override.is_empty():
-		return profile
-	return _merge_profile(profile, _profile_override)
+func _refresh_profile_cache() -> void:
+	var base_profile: Dictionary = SEGMENT_PROFILES[min(_segment_index, SEGMENT_PROFILES.size() - 1)]
+	var resolved := base_profile if _profile_override.is_empty() else _merge_profile(base_profile, _profile_override)
+	_base_ratio = float(resolved["base"])
+	_amplitude = float(resolved["amp"])
+	_freq_a = float(resolved.get("freq_a", 0.0089))
+	_freq_b = float(resolved.get("freq_b", 0.019))
+	_freq_c = float(resolved.get("freq_c", 0.0037))
+	_weight_b = float(resolved.get("weight_b", 0.46))
+	_weight_c = float(resolved.get("weight_c", 0.80))
+	_jagged = float(resolved.get("jagged", 0.0))
+	_sample_step = maxf(8.0, float(resolved.get("step", 20.0)))
+	_fill_color = resolved["fill"]
+	_line_color = resolved["line"]
+
+func _ceiling_height_for_world_x(world_x: float, viewport_height: float) -> float:
+	var y := viewport_height * _base_ratio
+	y += sin(world_x * _freq_a) * _amplitude
+	y += cos(world_x * _freq_b) * _amplitude * _weight_b
+	y += sin(world_x * _freq_c) * _amplitude * _weight_c
+	if _jagged > 0.0:
+		y += snapped(cos(world_x * 0.14), 0.2) * _amplitude * 0.30 * _jagged
+	return clampf(y, 26.0, viewport_height * 0.42)
 
 func _merge_profile(base: Dictionary, override: Dictionary) -> Dictionary:
 	var merged: Dictionary = base.duplicate(true)

--- a/scripts/game_state.gd
+++ b/scripts/game_state.gd
@@ -74,9 +74,12 @@ func update(delta: float) -> void:
 	if not run_started or is_paused:
 		return
 	if not is_alive and lives > 0:
+		var previous_respawn_tenths := _respawn_tenths_remaining()
 		_respawn_remaining = maxf(0.0, _respawn_remaining - delta)
 		if _respawn_remaining <= 0.0:
 			respawn()
+		elif _respawn_tenths_remaining() != previous_respawn_tenths:
+			changed.emit()
 
 func respawn() -> void:
 	if lives <= 0:
@@ -94,3 +97,6 @@ func status_text() -> String:
 	if is_alive:
 		return "Alive"
 	return "Respawning in %.1fs" % _respawn_remaining
+
+func _respawn_tenths_remaining() -> int:
+	return maxi(0, int(round(_respawn_remaining * 10.0)))

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -71,6 +71,27 @@ const DEFAULT_KEY_BINDINGS := {
 const INPUT_BINDINGS_SETTINGS_PATH := "user://settings.cfg"
 const INPUT_BINDINGS_SECTION := "input_bindings"
 const START_SUBMENU_OPTIONS := ["start", "controls", "window_mode", "back"]
+const INPUT_DEBUG_ACTIONS: Array[String] = [
+	"move_up",
+	"move_down",
+	"move_left",
+	"move_right",
+	"fire",
+	"bomb",
+	"start",
+	"pause",
+	"toggle_fullscreen"
+]
+const DEFAULT_SFX_POOL_SIZE := 6
+
+enum TrackedNodeList {
+	ENEMIES,
+	LASER_BOLTS,
+	BOMB_PAYLOADS,
+	BOMB_BLASTS,
+	COMBAT_VFX,
+	FUEL_TANKS
+}
 
 @onready var player: Node2D = $PlayerShip
 @onready var hud: Control = $CanvasLayer/HUD
@@ -107,6 +128,14 @@ var rng := RandomNumberGenerator.new()
 var background_layer = null
 var ceiling_layer = null
 var terrain_layer = null
+var _enemy_nodes: Array[Node2D] = []
+var _laser_bolt_nodes: Array[Node2D] = []
+var _bomb_payload_nodes: Array[Node2D] = []
+var _bomb_blast_nodes: Array[Node2D] = []
+var _combat_vfx_nodes: Array[Node2D] = []
+var _fuel_tank_nodes: Array[Node2D] = []
+var _sfx_players: Array[AudioStreamPlayer] = []
+var _available_sfx_players: Array[AudioStreamPlayer] = []
 var remap_selected_index := 0
 var is_remap_menu_open := false
 var awaiting_rebind := false
@@ -116,31 +145,64 @@ var screen_shake_strength := 0.0
 var screen_shake_remaining := 0.0
 var _last_visual_segment_index := -1
 var stage_transition_remaining := 0.0
-var current_enemy_style: Dictionary = {}
 var start_menu_selected_index := 0
 var is_start_menu_details_open := false
 var start_submenu_selected_index := 0
 var is_start_controls_open := false
 var _last_input_debug_text := ""
 var _last_player_top_margin := -1.0
+var _actors_active := false
+var _last_title_overlay_visible := false
+var _last_pause_visible := false
+var _last_game_over_state := false
+var _last_info_label_key := ""
+var _last_state_label_text := ""
+var _last_fuel_value := -1.0
+var _last_fuel_value_text := ""
+var _last_action_label_text := ""
+var _last_pause_options_text := ""
+var _last_remap_list_text := ""
+var _last_remap_status_label_text := ""
 
 func _ready() -> void:
 	rng.randomize()
 	_load_startup_art()
 	_create_world_layers()
+	_prewarm_sfx_pool()
 	_load_stage_segments()
 	_ensure_fullscreen_input_action()
 	_load_input_bindings()
-	game_state.changed.connect(_update_hud)
+	game_state.changed.connect(_on_game_state_changed)
 	game_state.action_triggered.connect(_on_action_triggered)
 	game_state.player_died.connect(_on_player_died)
 	game_state.player_respawned.connect(_on_respawned)
-	_update_hud()
+	_on_game_state_changed()
 	_sync_player_playfield_bounds()
-	_set_pause_ui_visibility()
-	_update_pause_menu()
-	_update_remap_panel()
-	_update_start_screen_ui()
+	_refresh_stateful_ui(true)
+
+func _on_game_state_changed() -> void:
+	_update_hud()
+	_refresh_stateful_ui()
+
+func _refresh_stateful_ui(force := false) -> void:
+	var title_overlay_visible := _is_title_overlay_visible()
+	var game_over_state := _is_game_over()
+	var pause_visible: bool = game_state.run_started and game_state.is_paused and not game_over_state
+	var info_key := "%s|%s|%s" % [game_state.run_started, game_state.is_paused, game_state.stage_id]
+
+	if force or info_key != _last_info_label_key:
+		_last_info_label_key = info_key
+		_update_info_label()
+
+	if force or pause_visible != _last_pause_visible:
+		_last_pause_visible = pause_visible
+		_set_pause_ui_visibility()
+		_update_pause_menu()
+
+	if force or title_overlay_visible != _last_title_overlay_visible or game_over_state != _last_game_over_state:
+		_last_title_overlay_visible = title_overlay_visible
+		_last_game_over_state = game_over_state
+		_update_start_screen_ui()
 
 func _sync_player_playfield_bounds() -> void:
 	if player == null or hud == null:
@@ -164,6 +226,74 @@ func _assign_texture_from_image(target: TextureRect, image_path: String) -> void
 		push_warning("Failed to load startup art: %s" % image_path)
 		return
 	target.texture = ImageTexture.create_from_image(image)
+
+func _prewarm_sfx_pool() -> void:
+	for _i in range(DEFAULT_SFX_POOL_SIZE):
+		_create_sfx_player()
+
+func _create_sfx_player() -> AudioStreamPlayer:
+	var player_node := AudioStreamPlayer.new()
+	add_child(player_node)
+	player_node.finished.connect(_on_sfx_player_finished.bind(player_node))
+	_sfx_players.append(player_node)
+	_available_sfx_players.append(player_node)
+	return player_node
+
+func _acquire_sfx_player() -> AudioStreamPlayer:
+	if _available_sfx_players.is_empty():
+		return _create_sfx_player()
+	return _available_sfx_players.pop_back()
+
+func _on_sfx_player_finished(player_node: AudioStreamPlayer) -> void:
+	player_node.stop()
+	if not _available_sfx_players.has(player_node):
+		_available_sfx_players.append(player_node)
+
+func _reset_sfx_pool() -> void:
+	_available_sfx_players.clear()
+	for player_node in _sfx_players:
+		player_node.stop()
+		_available_sfx_players.append(player_node)
+
+func _track_spawned_node(node: Node2D, tracked_list: int) -> void:
+	match tracked_list:
+		TrackedNodeList.ENEMIES:
+			_enemy_nodes.append(node)
+		TrackedNodeList.LASER_BOLTS:
+			_laser_bolt_nodes.append(node)
+		TrackedNodeList.BOMB_PAYLOADS:
+			_bomb_payload_nodes.append(node)
+		TrackedNodeList.BOMB_BLASTS:
+			_bomb_blast_nodes.append(node)
+		TrackedNodeList.COMBAT_VFX:
+			_combat_vfx_nodes.append(node)
+		TrackedNodeList.FUEL_TANKS:
+			_fuel_tank_nodes.append(node)
+	node.tree_exited.connect(_on_tracked_node_exited.bind(node, tracked_list), CONNECT_ONE_SHOT)
+
+func _on_tracked_node_exited(node: Node2D, tracked_list: int) -> void:
+	match tracked_list:
+		TrackedNodeList.ENEMIES:
+			_enemy_nodes.erase(node)
+		TrackedNodeList.LASER_BOLTS:
+			_laser_bolt_nodes.erase(node)
+		TrackedNodeList.BOMB_PAYLOADS:
+			_bomb_payload_nodes.erase(node)
+		TrackedNodeList.BOMB_BLASTS:
+			_bomb_blast_nodes.erase(node)
+		TrackedNodeList.COMBAT_VFX:
+			_combat_vfx_nodes.erase(node)
+		TrackedNodeList.FUEL_TANKS:
+			_fuel_tank_nodes.erase(node)
+
+func _circles_overlap(a: Vector2, b: Vector2, radius_sum: float) -> bool:
+	var dx := a.x - b.x
+	if absf(dx) > radius_sum:
+		return false
+	var dy := a.y - b.y
+	if absf(dy) > radius_sum:
+		return false
+	return dx * dx + dy * dy <= radius_sum * radius_sum
 
 func _unhandled_input(event: InputEvent) -> void:
 	var key_event := event as InputEventKey
@@ -410,7 +540,10 @@ func _process(delta: float) -> void:
 	if Input.is_action_just_pressed("toggle_fullscreen"):
 		_toggle_fullscreen()
 
-	if game_state.run_started and game_state.is_alive and not game_state.is_paused:
+	var run_unpaused: bool = game_state.run_started and not game_state.is_paused
+	var run_active: bool = run_unpaused and game_state.is_alive
+
+	if run_active:
 		if stage_transition_remaining > 0.0:
 			_update_stage_transition(delta)
 		else:
@@ -433,12 +566,16 @@ func _process(delta: float) -> void:
 			game_state.add_fuel(REFUEL_PER_SECOND * delta)
 
 		_update_combat_state()
-		game_state.update(delta)
 		_update_world_layers()
 		_update_ground_enemy_attachment()
-		player.visible = game_state.is_alive
-	player.set_physics_process(game_state.run_started and game_state.is_alive and not game_state.is_paused)
-	_set_actor_activity(game_state.run_started and game_state.is_alive and not game_state.is_paused)
+
+	if run_unpaused:
+		game_state.update(delta)
+
+	player.visible = game_state.is_alive
+	var actors_should_run: bool = game_state.run_started and game_state.is_alive and not game_state.is_paused
+	player.set_physics_process(actors_should_run)
+	_set_actor_activity(actors_should_run)
 	_update_input_debug()
 	_update_screen_shake(delta)
 
@@ -448,6 +585,7 @@ func _start_run() -> void:
 	position = Vector2.ZERO
 	screen_shake_strength = 0.0
 	screen_shake_remaining = 0.0
+	_reset_sfx_pool()
 	_clear_combat_nodes()
 	_reset_run_progression()
 	enemy_spawn_remaining = 0.35
@@ -458,10 +596,8 @@ func _start_run() -> void:
 	start_menu_selected_index = 0
 	start_submenu_selected_index = 0
 	is_start_controls_open = false
-	_set_pause_ui_visibility()
-	_update_pause_menu()
+	_refresh_stateful_ui(true)
 	_update_remap_panel()
-	_update_start_screen_ui()
 
 func _start_menu_option_line(index: int, label: String) -> String:
 	var marker := ">" if start_submenu_selected_index == index else " "
@@ -480,13 +616,13 @@ func _play_sfx(cue_name: String, volume_db := -8.0, pitch_jitter := 0.06) -> voi
 	var stream: AudioStreamWAV = SFX_SYNTH_SCRIPT.stream_for(cue_name)
 	if stream == null:
 		return
-	var sfx_player := AudioStreamPlayer.new()
+	var sfx_player := _acquire_sfx_player()
 	sfx_player.stream = stream
 	sfx_player.volume_db = volume_db
 	if pitch_jitter > 0.0:
 		sfx_player.pitch_scale = rng.randf_range(1.0 - pitch_jitter, 1.0 + pitch_jitter)
-	add_child(sfx_player)
-	sfx_player.finished.connect(sfx_player.queue_free)
+	else:
+		sfx_player.pitch_scale = 1.0
 	sfx_player.play()
 
 func _spawn_impact_flash(world_position: Vector2, radius := 24.0, color := Color(1.0, 0.92, 0.58, 0.8)) -> void:
@@ -495,6 +631,7 @@ func _spawn_impact_flash(world_position: Vector2, radius := 24.0, color := Color
 	flash.set("end_radius", radius)
 	flash.set("fill_color", color)
 	add_child(flash)
+	_track_spawned_node(flash, TrackedNodeList.COMBAT_VFX)
 
 func _spawn_explosion(world_position: Vector2, major := false) -> void:
 	var explosion := EXPLOSION_PARTICLES_SCRIPT.new()
@@ -504,6 +641,7 @@ func _spawn_explosion(world_position: Vector2, major := false) -> void:
 		explosion.set("speed_max", 320.0)
 		explosion.set("lifetime", 0.48)
 	add_child(explosion)
+	_track_spawned_node(explosion, TrackedNodeList.COMBAT_VFX)
 
 func _trigger_screen_shake(strength: float, duration: float) -> void:
 	screen_shake_strength = maxf(screen_shake_strength, strength)
@@ -533,6 +671,7 @@ func _spawn_bolt() -> void:
 	var bolt := LASER_BOLT_SCRIPT.new()
 	bolt.position = player.position + BOLT_SPAWN_OFFSET
 	add_child(bolt)
+	_track_spawned_node(bolt, TrackedNodeList.LASER_BOLTS)
 	_play_sfx("fire", -12.0, 0.08)
 	_spawn_impact_flash(bolt.position + Vector2(-8.0, 0.0), 16.0, Color(0.95, 0.98, 0.72, 0.7))
 
@@ -558,6 +697,7 @@ func _spawn_enemy() -> void:
 		if rng.randf() < distant_chance:
 			enemy.set("is_distant", true)
 	add_child(enemy)
+	_track_spawned_node(enemy, TrackedNodeList.ENEMIES)
 
 func _air_spawn_y_at(screen_x: float) -> float:
 	var viewport_size := get_viewport_rect().size
@@ -602,6 +742,7 @@ func _drop_bomb() -> void:
 	var payload := BOMB_PAYLOAD_SCRIPT.new()
 	payload.position = player.position + BOMB_DROP_OFFSET
 	add_child(payload)
+	_track_spawned_node(payload, TrackedNodeList.BOMB_PAYLOADS)
 	_play_sfx("bomb_drop", -10.0, 0.04)
 
 func _spawn_fuel_tank() -> void:
@@ -617,6 +758,7 @@ func _spawn_fuel_tank() -> void:
 	var segment = _current_segment()
 	tank.set("fuel_amount", float(segment["fuel_tank_amount"]))
 	add_child(tank)
+	_track_spawned_node(tank, TrackedNodeList.FUEL_TANKS)
 
 func _update_fuel_tank_spawns(delta: float) -> void:
 	var segment = _current_segment()
@@ -632,40 +774,38 @@ func _update_combat_state() -> void:
 	if not game_state.run_started or not game_state.is_alive or game_state.is_paused:
 		return
 
-	var enemy_nodes := get_tree().get_nodes_in_group("enemy_targets")
-	var bolt_nodes := get_tree().get_nodes_in_group("laser_bolts")
-	var bomb_nodes := get_tree().get_nodes_in_group("bomb_payloads")
-	var fuel_tank_nodes := get_tree().get_nodes_in_group("fuel_tanks")
-	var ceiling_height := _ceiling_height_at(player.position.x)
-	var terrain_height := _terrain_height_at(player.position.x)
+	var player_position := player.position
+	var ceiling_height := _ceiling_height_at(player_position.x)
+	var terrain_height := _terrain_height_at(player_position.x)
 
-	if player.position.y - PLAYER_CEILING_CLEARANCE <= ceiling_height:
+	if player_position.y - PLAYER_CEILING_CLEARANCE <= ceiling_height:
 		_handle_player_death("Crashed into ceiling")
 		return
 
-	if player.position.y + PLAYER_TERRAIN_CLEARANCE >= terrain_height:
+	if player_position.y + PLAYER_TERRAIN_CLEARANCE >= terrain_height:
 		_handle_player_death("Crashed into terrain")
 		return
 
-	for enemy_node in enemy_nodes:
+	for enemy_node in _enemy_nodes:
 		if enemy_node == null or enemy_node.is_queued_for_deletion() or not enemy_node.has_method("apply_hit"):
 			continue
 
 		var enemy_type := String(enemy_node.get("target_type"))
 		var enemy_hit_radius := float(enemy_node.get("hit_radius"))
+		var enemy_position := enemy_node.position
 
-		if enemy_type == "air" and enemy_node.position.distance_to(player.position) <= (enemy_hit_radius + PLAYER_HIT_RADIUS):
+		if enemy_type == "air" and _circles_overlap(enemy_position, player_position, enemy_hit_radius + PLAYER_HIT_RADIUS):
 			enemy_node.apply_hit("ship")
 			_handle_player_death("Ship hit by enemy")
 			return
 
 		if enemy_type == "air":
-			for bolt_node in bolt_nodes:
+			for bolt_node in _laser_bolt_nodes:
 				if bolt_node == null or bolt_node.is_queued_for_deletion():
 					continue
 				var bolt_hit_radius := float(bolt_node.get("hit_radius"))
-				if bolt_node.position.distance_to(enemy_node.position) <= (bolt_hit_radius + enemy_hit_radius):
-					var impact_position := Vector2(enemy_node.position)
+				if _circles_overlap(bolt_node.position, enemy_position, bolt_hit_radius + enemy_hit_radius):
+					var impact_position := enemy_position
 					var air_points := int(enemy_node.apply_hit("laser"))
 					if air_points > 0:
 						game_state.add_score(air_points)
@@ -677,12 +817,15 @@ func _update_combat_state() -> void:
 					bolt_node.queue_free()
 					break
 
-		for bomb_node in bomb_nodes:
+		if enemy_node.is_queued_for_deletion():
+			continue
+
+		for bomb_node in _bomb_payload_nodes:
 			if bomb_node == null or bomb_node.is_queued_for_deletion():
 				continue
 			var bomb_hit_radius := float(bomb_node.get("hit_radius"))
-			if bomb_node.position.distance_to(enemy_node.position) <= (bomb_hit_radius + enemy_hit_radius):
-				var impact_position := Vector2(enemy_node.position)
+			if _circles_overlap(bomb_node.position, enemy_position, bomb_hit_radius + enemy_hit_radius):
+				var impact_position := enemy_position
 				var bomb_points := int(enemy_node.apply_hit("bomb"))
 				if bomb_points > 0:
 					game_state.add_score(bomb_points)
@@ -695,13 +838,13 @@ func _update_combat_state() -> void:
 				bomb_node.queue_free()
 				break
 
-	_process_bomb_ground_impacts(enemy_nodes, bomb_nodes)
+	_process_bomb_ground_impacts()
 
-	for fuel_tank_node in fuel_tank_nodes:
-		if fuel_tank_node == null:
+	for fuel_tank_node in _fuel_tank_nodes:
+		if fuel_tank_node == null or fuel_tank_node.is_queued_for_deletion():
 			continue
 		var tank_radius := float(fuel_tank_node.get("hit_radius"))
-		if fuel_tank_node.position.distance_to(player.position) <= (tank_radius + PLAYER_HIT_RADIUS):
+		if _circles_overlap(fuel_tank_node.position, player_position, tank_radius + PLAYER_HIT_RADIUS):
 			var fuel_gain := float(fuel_tank_node.get("fuel_amount"))
 			game_state.add_fuel(fuel_gain)
 			last_action_text = "Fuel tank collected (+%d)" % int(fuel_gain)
@@ -710,34 +853,35 @@ func _update_combat_state() -> void:
 			_spawn_impact_flash(fuel_tank_node.position, 20.0, Color(0.68, 0.96, 0.6, 0.78))
 			fuel_tank_node.queue_free()
 
-func _process_bomb_ground_impacts(enemy_nodes: Array, bomb_nodes: Array) -> void:
-	for bomb_node in bomb_nodes:
+func _process_bomb_ground_impacts() -> void:
+	for bomb_node in _bomb_payload_nodes:
 		if bomb_node == null or bomb_node.is_queued_for_deletion():
 			continue
 		var terrain_y := _terrain_height_at(bomb_node.position.x)
 		if bomb_node.position.y < terrain_y - 4.0:
 			continue
 		var impact_position := Vector2(bomb_node.position.x, terrain_y - 2.0)
-		_detonate_bomb_on_ground(impact_position, enemy_nodes)
+		_detonate_bomb_on_ground(impact_position)
 		bomb_node.queue_free()
 
-func _detonate_bomb_on_ground(impact_position: Vector2, enemy_nodes: Array) -> void:
+func _detonate_bomb_on_ground(impact_position: Vector2) -> void:
 	var blast := BOMB_BLAST_SCRIPT.new()
 	blast.position = impact_position
 	add_child(blast)
+	_track_spawned_node(blast, TrackedNodeList.BOMB_BLASTS)
 	_play_sfx("impact", -5.8, 0.05)
 	_spawn_impact_flash(impact_position, 40.0, Color(1.0, 0.78, 0.45, 0.82))
 	_spawn_explosion(impact_position, true)
 	_trigger_screen_shake(MAJOR_SHAKE_STRENGTH, 0.16)
 
 	var kills := 0
-	for enemy_node in enemy_nodes:
+	for enemy_node in _enemy_nodes:
 		if enemy_node == null or enemy_node.is_queued_for_deletion() or not enemy_node.has_method("apply_hit"):
 			continue
 		var enemy_hit_radius := float(enemy_node.get("hit_radius"))
-		if enemy_node.position.distance_to(impact_position) > (BOMB_GROUND_BLAST_RADIUS + enemy_hit_radius):
+		if not _circles_overlap(enemy_node.position, impact_position, BOMB_GROUND_BLAST_RADIUS + enemy_hit_radius):
 			continue
-		var enemy_position := Vector2(enemy_node.position)
+		var enemy_position := enemy_node.position
 		var points := int(enemy_node.apply_hit("bomb"))
 		if points <= 0:
 			continue
@@ -754,7 +898,7 @@ func _detonate_bomb_on_ground(impact_position: Vector2, enemy_nodes: Array) -> v
 	action_label.text = "Last Action: %s" % last_action_text
 
 func _update_ground_enemy_attachment() -> void:
-	for enemy_node in get_tree().get_nodes_in_group("enemy_targets"):
+	for enemy_node in _enemy_nodes:
 		if enemy_node == null or enemy_node.is_queued_for_deletion():
 			continue
 		if String(enemy_node.get("target_type")) != "ground":
@@ -762,32 +906,41 @@ func _update_ground_enemy_attachment() -> void:
 		enemy_node.position.y = _terrain_height_at(enemy_node.position.x) - GROUND_UNIT_CLEARANCE
 
 func _set_actor_activity(is_active: bool) -> void:
-	for bolt_node in get_tree().get_nodes_in_group("laser_bolts"):
+	if _actors_active == is_active:
+		return
+	_actors_active = is_active
+	for bolt_node in _laser_bolt_nodes:
 		if bolt_node != null:
 			bolt_node.set("is_active", is_active)
-	for bomb_node in get_tree().get_nodes_in_group("bomb_payloads"):
+	for bomb_node in _bomb_payload_nodes:
 		if bomb_node != null:
 			bomb_node.set("is_active", is_active)
-	for fuel_tank_node in get_tree().get_nodes_in_group("fuel_tanks"):
+	for fuel_tank_node in _fuel_tank_nodes:
 		if fuel_tank_node != null:
 			fuel_tank_node.set("is_active", is_active)
-	for enemy_node in get_tree().get_nodes_in_group("enemy_targets"):
+	for enemy_node in _enemy_nodes:
 		if enemy_node != null:
 			enemy_node.set("is_active", is_active)
 
 func _clear_combat_nodes() -> void:
-	for bolt_node in get_tree().get_nodes_in_group("laser_bolts"):
+	for bolt_node in _laser_bolt_nodes:
 		bolt_node.queue_free()
-	for bomb_node in get_tree().get_nodes_in_group("bomb_payloads"):
+	for bomb_node in _bomb_payload_nodes:
 		bomb_node.queue_free()
-	for blast_node in get_tree().get_nodes_in_group("bomb_blasts"):
+	for blast_node in _bomb_blast_nodes:
 		blast_node.queue_free()
-	for vfx_node in get_tree().get_nodes_in_group("combat_vfx"):
+	for vfx_node in _combat_vfx_nodes:
 		vfx_node.queue_free()
-	for fuel_tank_node in get_tree().get_nodes_in_group("fuel_tanks"):
+	for fuel_tank_node in _fuel_tank_nodes:
 		fuel_tank_node.queue_free()
-	for enemy_node in get_tree().get_nodes_in_group("enemy_targets"):
+	for enemy_node in _enemy_nodes:
 		enemy_node.queue_free()
+	_laser_bolt_nodes.clear()
+	_bomb_payload_nodes.clear()
+	_bomb_blast_nodes.clear()
+	_combat_vfx_nodes.clear()
+	_fuel_tank_nodes.clear()
+	_enemy_nodes.clear()
 
 func _create_world_layers() -> void:
 	if background_layer == null:
@@ -806,15 +959,18 @@ func _create_world_layers() -> void:
 
 func _update_world_layers() -> void:
 	if background_layer != null:
-		background_layer.call("set_scroll_distance", run_distance)
-		background_layer.call("set_segment_index", current_segment_index)
+		background_layer.set_scroll_distance(run_distance)
 	if ceiling_layer != null:
-		ceiling_layer.call("set_scroll_distance", run_distance)
-		ceiling_layer.call("set_segment_index", current_segment_index)
+		ceiling_layer.set_scroll_distance(run_distance)
 	if terrain_layer != null:
-		terrain_layer.call("set_scroll_distance", run_distance)
-		terrain_layer.call("set_segment_index", current_segment_index)
+		terrain_layer.set_scroll_distance(run_distance)
 	if current_segment_index != _last_visual_segment_index:
+		if background_layer != null:
+			background_layer.set_segment_index(current_segment_index)
+		if ceiling_layer != null:
+			ceiling_layer.set_segment_index(current_segment_index)
+		if terrain_layer != null:
+			terrain_layer.set_segment_index(current_segment_index)
 		_apply_segment_visuals()
 		_last_visual_segment_index = current_segment_index
 
@@ -824,24 +980,22 @@ func _apply_segment_visuals() -> void:
 	var ceiling_profile: Dictionary = segment.get("ceiling_profile", {})
 	var sky_palette: Dictionary = segment.get("sky_palette", {})
 	var background_style: Dictionary = segment.get("background_style", {})
-	current_enemy_style = segment.get("enemy_style", {})
-	if background_layer != null and background_layer.has_method("set_palette_override"):
-		background_layer.call("set_palette_override", sky_palette)
-	if background_layer != null and background_layer.has_method("set_style_override"):
-		background_layer.call("set_style_override", background_style)
-	if ceiling_layer != null and ceiling_layer.has_method("set_profile_override"):
-		ceiling_layer.call("set_profile_override", ceiling_profile)
-	if terrain_layer != null and terrain_layer.has_method("set_profile_override"):
-		terrain_layer.call("set_profile_override", terrain_profile)
+	if background_layer != null:
+		background_layer.set_palette_override(sky_palette)
+		background_layer.set_style_override(background_style)
+	if ceiling_layer != null:
+		ceiling_layer.set_profile_override(ceiling_profile)
+	if terrain_layer != null:
+		terrain_layer.set_profile_override(terrain_profile)
 
 func _ceiling_height_at(screen_x: float) -> float:
-	if ceiling_layer != null and ceiling_layer.has_method("ceiling_height_at_screen_x"):
-		return float(ceiling_layer.call("ceiling_height_at_screen_x", screen_x))
+	if ceiling_layer != null:
+		return ceiling_layer.ceiling_height_at_screen_x(screen_x)
 	return 80.0
 
 func _terrain_height_at(screen_x: float) -> float:
-	if terrain_layer != null and terrain_layer.has_method("ground_height_at_screen_x"):
-		return float(terrain_layer.call("ground_height_at_screen_x", screen_x))
+	if terrain_layer != null:
+		return terrain_layer.ground_height_at_screen_x(screen_x)
 	return ENEMY_GROUND_Y
 
 func _spawn_x() -> float:
@@ -933,20 +1087,29 @@ func _on_respawned() -> void:
 	last_action_text = "Respawned"
 
 func _update_hud() -> void:
-	state_label.text = "SCR %05d    LIV %d    STG %d    %s" % [
+	var next_state_label := "SCR %05d    LIV %d    STG %d    %s" % [
 		game_state.score,
 		max(game_state.lives, 0),
 		game_state.stage_id,
 		game_state.status_text()
 	]
-	fuel_bar.value = game_state.fuel
-	fuel_value_label.text = "%05.1f%%" % game_state.fuel
-	action_label.text = "LOG  %s" % String(last_action_text)
-	_update_info_label()
-	_set_pause_ui_visibility()
-	_update_pause_menu()
-	_update_remap_panel()
-	_update_start_screen_ui()
+	if next_state_label != _last_state_label_text:
+		_last_state_label_text = next_state_label
+		state_label.text = next_state_label
+
+	if not is_equal_approx(_last_fuel_value, game_state.fuel):
+		_last_fuel_value = game_state.fuel
+		fuel_bar.value = game_state.fuel
+
+	var next_fuel_text := "%05.1f%%" % game_state.fuel
+	if next_fuel_text != _last_fuel_value_text:
+		_last_fuel_value_text = next_fuel_text
+		fuel_value_label.text = next_fuel_text
+
+	var next_action_label := "LOG  %s" % String(last_action_text)
+	if next_action_label != _last_action_label_text:
+		_last_action_label_text = next_action_label
+		action_label.text = next_action_label
 
 func _update_info_label() -> void:
 	var segment = _current_segment()
@@ -958,16 +1121,17 @@ func _update_info_label() -> void:
 		_action_binding_text("fire"),
 		_action_binding_text("bomb")
 	]
+	var next_text := base_text
 	if game_state.run_started and game_state.is_paused:
-		info_label.text = "%s    1 RESUME  2 RETRY  3 WINDOW  4 REMAP" % base_text
-	else:
-		info_label.text = base_text
+		next_text = "%s    1 RESUME  2 RETRY  3 WINDOW  4 REMAP" % base_text
+	if info_label.text != next_text:
+		info_label.text = next_text
 
 func _update_input_debug() -> void:
 	if input_label == null or not input_label.visible:
 		return
 	var pressed_actions: Array[String] = []
-	for action in ["move_up", "move_down", "move_left", "move_right", "fire", "bomb", "start", "pause", "toggle_fullscreen"]:
+	for action in INPUT_DEBUG_ACTIONS:
 		if Input.is_action_pressed(action):
 			pressed_actions.append(action)
 	var pressed_text := "none" if pressed_actions.is_empty() else ", ".join(pressed_actions)
@@ -1004,6 +1168,7 @@ func _toggle_fullscreen() -> void:
 	last_action_text = "Display mode switched to %s" % mode_label
 	action_label.text = "Last Action: %s" % last_action_text
 	_update_pause_menu()
+	_update_start_screen_ui()
 
 func _set_pause_ui_visibility() -> void:
 	var pause_visible: bool = game_state.run_started and game_state.is_paused and not _is_game_over()
@@ -1015,11 +1180,19 @@ func _update_pause_menu() -> void:
 	var mode_name := "Fullscreen"
 	if current_mode == DisplayServer.WINDOW_MODE_WINDOWED:
 		mode_name = "Windowed"
-	pause_options_label.text = "1 Resume\n2 Retry Run\n3 Toggle Window Mode (%s)\n4 Input Remap" % mode_name
+	var next_text := "1 Resume\n2 Retry Run\n3 Toggle Window Mode (%s)\n4 Input Remap" % mode_name
+	if next_text != _last_pause_options_text:
+		_last_pause_options_text = next_text
+		pause_options_label.text = next_text
 
 func _update_remap_panel() -> void:
-	remap_status_label.text = remap_status_text
-	remap_list_label.text = _remap_list_text() + "\nBackspace resets selected action."
+	if remap_status_text != _last_remap_status_label_text:
+		_last_remap_status_label_text = remap_status_text
+		remap_status_label.text = remap_status_text
+	var next_list_text := _remap_list_text() + "\nBackspace resets selected action."
+	if next_list_text != _last_remap_list_text:
+		_last_remap_list_text = next_list_text
+		remap_list_label.text = next_list_text
 
 func _selected_remap_action() -> String:
 	return REMAP_ACTIONS[clampi(remap_selected_index, 0, REMAP_ACTIONS.size() - 1)]
@@ -1059,6 +1232,8 @@ func _rebind_action(action_name: String, source_event: InputEventKey) -> void:
 	InputMap.action_add_event(action_name, rebound_event)
 	remap_status_text = "%s mapped to %s." % [_action_label(action_name), _action_binding_text(action_name)]
 	_save_input_bindings()
+	_last_info_label_key = ""
+	_update_info_label()
 
 func _reset_action_binding(action_name: String) -> void:
 	InputMap.action_erase_events(action_name)
@@ -1070,6 +1245,8 @@ func _reset_action_binding(action_name: String) -> void:
 		InputMap.action_add_event(action_name, default_event)
 	remap_status_text = "%s reset to %s." % [_action_label(action_name), _action_binding_text(action_name)]
 	_save_input_bindings()
+	_last_info_label_key = ""
+	_update_info_label()
 
 func _load_input_bindings() -> void:
 	var settings := ConfigFile.new()

--- a/scripts/parallax_background.gd
+++ b/scripts/parallax_background.gd
@@ -2,38 +2,91 @@ extends Node2D
 
 const SPACEPORT_SPIRES_TEXTURE := preload("res://assets/concept_samples/props/spaceport_spires.svg")
 const MONOLITH_GATE_TEXTURE := preload("res://assets/concept_samples/props/monolith_gate.svg")
+const SEGMENT_PALETTES := [
+	{
+		"sky": Color(0.39, 0.62, 0.84),
+		"haze": Color(0.53, 0.69, 0.78, 0.8),
+		"cloud": Color(0.92, 0.95, 1.0, 0.45),
+		"far_hill": Color(0.22, 0.40, 0.48),
+		"mid_hill": Color(0.15, 0.32, 0.38)
+	},
+	{
+		"sky": Color(0.47, 0.56, 0.70),
+		"haze": Color(0.60, 0.58, 0.50, 0.75),
+		"cloud": Color(0.88, 0.84, 0.77, 0.38),
+		"far_hill": Color(0.36, 0.33, 0.28),
+		"mid_hill": Color(0.29, 0.24, 0.18)
+	},
+	{
+		"sky": Color(0.30, 0.35, 0.50),
+		"haze": Color(0.41, 0.38, 0.45, 0.72),
+		"cloud": Color(0.74, 0.72, 0.88, 0.34),
+		"far_hill": Color(0.22, 0.19, 0.30),
+		"mid_hill": Color(0.16, 0.13, 0.22)
+	}
+]
+const SEGMENT_STYLES := [
+	{"mode": "atmosphere", "planet_scale": 1.0, "cloud_density": 1.0},
+	{"mode": "atmosphere", "planet_scale": 1.2, "cloud_density": 0.8},
+	{"mode": "space", "planet_scale": 1.4, "star_density": 1.3}
+]
 
 var _scroll_distance := 0.0
 var _segment_index := 0
 var _palette_override: Dictionary = {}
 var _style_override: Dictionary = {}
+var _resolved_palette: Dictionary = SEGMENT_PALETTES[0]
+var _resolved_style: Dictionary = SEGMENT_STYLES[0]
 
 func set_scroll_distance(distance: float) -> void:
+	if is_equal_approx(_scroll_distance, distance):
+		return
 	_scroll_distance = distance
 	queue_redraw()
 
 func set_segment_index(index: int) -> void:
-	_segment_index = max(index, 0)
+	var next_index: int = max(index, 0)
+	if _segment_index == next_index:
+		return
+	_segment_index = next_index
+	_refresh_palette_cache()
+	_refresh_style_cache()
 	queue_redraw()
 
 func set_palette_override(palette: Dictionary) -> void:
-	if typeof(palette) == TYPE_DICTIONARY:
-		_palette_override = palette
-	else:
-		_palette_override = {}
+	var next_override: Dictionary = palette if typeof(palette) == TYPE_DICTIONARY else {}
+	if _palette_override == next_override:
+		return
+	_palette_override = next_override
+	_refresh_palette_cache()
 	queue_redraw()
 
 func set_style_override(style: Dictionary) -> void:
-	if typeof(style) == TYPE_DICTIONARY:
-		_style_override = style
-	else:
-		_style_override = {}
+	var next_override: Dictionary = style if typeof(style) == TYPE_DICTIONARY else {}
+	if _style_override == next_override:
+		return
+	_style_override = next_override
+	_refresh_style_cache()
 	queue_redraw()
+
+func _refresh_palette_cache() -> void:
+	var base_palette: Dictionary = SEGMENT_PALETTES[min(_segment_index, SEGMENT_PALETTES.size() - 1)]
+	_resolved_palette = base_palette if _palette_override.is_empty() else _merge_palette(base_palette, _palette_override)
+
+func _refresh_style_cache() -> void:
+	var base_style: Dictionary = SEGMENT_STYLES[min(_segment_index, SEGMENT_STYLES.size() - 1)]
+	if _style_override.is_empty():
+		_resolved_style = base_style
+		return
+	var merged: Dictionary = base_style.duplicate(true)
+	for key in _style_override.keys():
+		merged[key] = _style_override[key]
+	_resolved_style = merged
 
 func _draw() -> void:
 	var size := get_viewport_rect().size
-	var palette := _palette_for_segment(_segment_index)
-	var style := _style_for_segment(_segment_index)
+	var palette := _resolved_palette
+	var style := _resolved_style
 
 	draw_rect(Rect2(Vector2.ZERO, size), palette["sky"])
 	draw_rect(Rect2(Vector2(0, size.y * 0.48), Vector2(size.x, size.y * 0.52)), palette["haze"])
@@ -171,31 +224,6 @@ func _draw_hill_band(size: Vector2, parallax: float, base_y: float, amplitude: f
 		var y := base_y + sin(world_x * 0.0103) * amplitude + cos(world_x * 0.0048) * amplitude * 0.65
 		draw_line(Vector2(x, y), Vector2(x, size.y), color, step + 1.0)
 		x += step
-
-func _palette_for_segment(index: int) -> Dictionary:
-	var palettes := [
-		{"sky": Color(0.39, 0.62, 0.84), "haze": Color(0.53, 0.69, 0.78, 0.8), "cloud": Color(0.92, 0.95, 1.0, 0.45), "far_hill": Color(0.22, 0.40, 0.48), "mid_hill": Color(0.15, 0.32, 0.38)},
-		{"sky": Color(0.47, 0.56, 0.70), "haze": Color(0.60, 0.58, 0.50, 0.75), "cloud": Color(0.88, 0.84, 0.77, 0.38), "far_hill": Color(0.36, 0.33, 0.28), "mid_hill": Color(0.29, 0.24, 0.18)},
-		{"sky": Color(0.30, 0.35, 0.50), "haze": Color(0.41, 0.38, 0.45, 0.72), "cloud": Color(0.74, 0.72, 0.88, 0.34), "far_hill": Color(0.22, 0.19, 0.30), "mid_hill": Color(0.16, 0.13, 0.22)}
-	]
-	var palette: Dictionary = palettes[min(index, palettes.size() - 1)]
-	if _palette_override.is_empty():
-		return palette
-	return _merge_palette(palette, _palette_override)
-
-func _style_for_segment(index: int) -> Dictionary:
-	var defaults := [
-		{"mode": "atmosphere", "planet_scale": 1.0, "cloud_density": 1.0},
-		{"mode": "atmosphere", "planet_scale": 1.2, "cloud_density": 0.8},
-		{"mode": "space", "planet_scale": 1.4, "star_density": 1.3}
-	]
-	var style: Dictionary = defaults[min(index, defaults.size() - 1)]
-	if _style_override.is_empty():
-		return style
-	var merged := style.duplicate(true)
-	for key in _style_override.keys():
-		merged[key] = _style_override[key]
-	return merged
 
 func _merge_palette(base: Dictionary, override: Dictionary) -> Dictionary:
 	var merged: Dictionary = base.duplicate(true)

--- a/scripts/terrain_band.gd
+++ b/scripts/terrain_band.gd
@@ -1,8 +1,40 @@
 extends Node2D
 
+const SEGMENT_PROFILES := [
+	{
+		"base": 0.84,
+		"amp": 18.0,
+		"fill": Color(0.18, 0.23, 0.16),
+		"line": Color(0.30, 0.42, 0.24)
+	},
+	{
+		"base": 0.82,
+		"amp": 30.0,
+		"fill": Color(0.25, 0.20, 0.14),
+		"line": Color(0.45, 0.36, 0.23)
+	},
+	{
+		"base": 0.80,
+		"amp": 38.0,
+		"fill": Color(0.20, 0.16, 0.22),
+		"line": Color(0.36, 0.28, 0.44)
+	}
+]
+
 var _scroll_distance := 0.0
 var _segment_index := 0
 var _profile_override: Dictionary = {}
+var _base_ratio := 0.84
+var _amplitude := 18.0
+var _freq_a := 0.0105
+var _freq_b := 0.027
+var _freq_c := 0.0041
+var _weight_b := 0.42
+var _weight_c := 0.58
+var _jagged := 0.0
+var _sample_step := 20.0
+var _fill_color := Color(0.18, 0.23, 0.16)
+var _line_color := Color(0.30, 0.42, 0.24)
 
 const BASE_MIN := 0.55
 const BASE_MAX := 0.95
@@ -10,98 +42,84 @@ const AMP_MIN := 4.0
 const AMP_MAX := 160.0
 
 func set_scroll_distance(distance: float) -> void:
+	if is_equal_approx(_scroll_distance, distance):
+		return
 	_scroll_distance = distance
 	queue_redraw()
 
 func set_segment_index(index: int) -> void:
-	_segment_index = max(index, 0)
+	var next_index: int = max(index, 0)
+	if _segment_index == next_index:
+		return
+	_segment_index = next_index
+	_refresh_profile_cache()
 	queue_redraw()
 
 func set_profile_override(profile: Dictionary) -> void:
-	if typeof(profile) == TYPE_DICTIONARY:
-		_profile_override = profile
-	else:
-		_profile_override = {}
+	var next_override: Dictionary = profile if typeof(profile) == TYPE_DICTIONARY else {}
+	if _profile_override == next_override:
+		return
+	_profile_override = next_override
+	_refresh_profile_cache()
 	queue_redraw()
 
 func ground_height_at_screen_x(screen_x: float) -> float:
 	var size := get_viewport_rect().size
-	var profile := _profile_for_segment(_segment_index)
-	var world_x := screen_x + _scroll_distance
-	var base := size.y * float(profile["base"])
-	var amp := float(profile["amp"])
-	var freq_a := float(profile.get("freq_a", 0.0105))
-	var freq_b := float(profile.get("freq_b", 0.027))
-	var freq_c := float(profile.get("freq_c", 0.0041))
-	var weight_b := float(profile.get("weight_b", 0.42))
-	var weight_c := float(profile.get("weight_c", 0.58))
-	var jagged := float(profile.get("jagged", 0.0))
-	var y := base
-	y += sin(world_x * freq_a) * amp
-	y += sin(world_x * freq_b) * amp * weight_b
-	y += cos(world_x * freq_c) * amp * weight_c
-	if jagged > 0.0:
-		y += (snapped(sin(world_x * 0.11), 0.2) * amp * 0.35 * jagged)
-	return clampf(y, size.y * 0.55, size.y - 34.0)
+	return _ground_height_for_world_x(screen_x + _scroll_distance, size.y)
 
 func _draw() -> void:
 	var size := get_viewport_rect().size
-	var profile := _profile_for_segment(_segment_index)
-	var fill_color: Color = profile["fill"]
-	var line_color: Color = profile["line"]
 	var points := PackedVector2Array()
 	var ridge := PackedVector2Array()
 
 	points.push_back(Vector2(0, size.y))
-	var step := maxf(8.0, float(profile.get("step", 20.0)))
+	var step := _sample_step
 	var x := 0.0
 	while x <= size.x + step:
-		var y := ground_height_at_screen_x(x)
+		var y := _ground_height_for_world_x(x + _scroll_distance, size.y)
 		var point := Vector2(x, y)
 		points.push_back(point)
 		ridge.push_back(point)
 		x += step
 	points.push_back(Vector2(size.x + step, size.y))
 
-	draw_colored_polygon(points, fill_color)
-	draw_polyline(ridge, line_color, 2.5)
-	_draw_detail_stripes(size, profile, ridge)
+	draw_colored_polygon(points, _fill_color)
+	draw_polyline(ridge, _line_color, 2.5)
+	_draw_detail_stripes(size, ridge)
 
-func _draw_detail_stripes(size: Vector2, profile: Dictionary, ridge: PackedVector2Array) -> void:
+func _draw_detail_stripes(size: Vector2, ridge: PackedVector2Array) -> void:
 	if ridge.size() < 2:
 		return
-	var stripe_color := Color(profile["line"]).lerp(Color.WHITE, 0.12)
+	var stripe_color := _line_color.lerp(Color.WHITE, 0.12)
 	stripe_color.a = 0.22
 	for i in range(0, ridge.size(), 2):
 		var p := ridge[i]
 		var stripe_depth := 22.0 + sin((p.x + _scroll_distance) * 0.08) * 6.0
 		draw_line(p + Vector2(0, 1), Vector2(p.x, minf(size.y, p.y + stripe_depth)), stripe_color, 1.0)
 
-func _profile_for_segment(index: int) -> Dictionary:
-	var profiles := [
-		{
-			"base": 0.84,
-			"amp": 18.0,
-			"fill": Color(0.18, 0.23, 0.16),
-			"line": Color(0.30, 0.42, 0.24)
-		},
-		{
-			"base": 0.82,
-			"amp": 30.0,
-			"fill": Color(0.25, 0.20, 0.14),
-			"line": Color(0.45, 0.36, 0.23)
-		},
-		{
-			"base": 0.80,
-			"amp": 38.0,
-			"fill": Color(0.20, 0.16, 0.22),
-			"line": Color(0.36, 0.28, 0.44)
-		}
-	]
-	var profile: Dictionary = profiles[min(index, profiles.size() - 1)]
-	if _profile_override.is_empty():
-		return profile
-	return _merge_profile(profile, _profile_override)
+func _refresh_profile_cache() -> void:
+	var base_profile: Dictionary = SEGMENT_PROFILES[min(_segment_index, SEGMENT_PROFILES.size() - 1)]
+	var resolved := base_profile if _profile_override.is_empty() else _merge_profile(base_profile, _profile_override)
+	_base_ratio = float(resolved["base"])
+	_amplitude = float(resolved["amp"])
+	_freq_a = float(resolved.get("freq_a", 0.0105))
+	_freq_b = float(resolved.get("freq_b", 0.027))
+	_freq_c = float(resolved.get("freq_c", 0.0041))
+	_weight_b = float(resolved.get("weight_b", 0.42))
+	_weight_c = float(resolved.get("weight_c", 0.58))
+	_jagged = float(resolved.get("jagged", 0.0))
+	_sample_step = maxf(8.0, float(resolved.get("step", 20.0)))
+	_fill_color = resolved["fill"]
+	_line_color = resolved["line"]
+
+func _ground_height_for_world_x(world_x: float, viewport_height: float) -> float:
+	var y := viewport_height * _base_ratio
+	y += sin(world_x * _freq_a) * _amplitude
+	y += sin(world_x * _freq_b) * _amplitude * _weight_b
+	y += cos(world_x * _freq_c) * _amplitude * _weight_c
+	if _jagged > 0.0:
+		y += snapped(sin(world_x * 0.11), 0.2) * _amplitude * 0.35 * _jagged
+	return clampf(y, viewport_height * 0.55, viewport_height - 34.0)
 
 func _merge_profile(base: Dictionary, override: Dictionary) -> Dictionary:
 	var merged: Dictionary = base.duplicate(true)

--- a/tests/run_tests.gd
+++ b/tests/run_tests.gd
@@ -1,6 +1,8 @@
 extends SceneTree
 
 const GameStateScript := preload("res://scripts/game_state.gd")
+const MainScript := preload("res://scripts/main.gd")
+const PlayerShipScript := preload("res://scripts/player_ship.gd")
 const StageSegmentSettingsScript := preload("res://scripts/stage_segment_settings.gd")
 
 var _passes := 0
@@ -24,6 +26,7 @@ func _run_all() -> void:
 	_run_test("stage segment settings normalize palette overrides", _test_stage_segment_settings_normalize_palette_overrides)
 	_run_test("scenario: full lifecycle to game over", _scenario_full_lifecycle_to_game_over)
 	_run_test("scenario: pause freezes fuel drain and then resumes", _scenario_pause_freeze_and_resume)
+	_run_test("main loop advances respawn after crash", _test_main_loop_advances_respawn_after_crash)
 
 func _run_test(name: String, body: Callable) -> void:
 	var failures_before := _failures
@@ -208,3 +211,25 @@ func _scenario_pause_freeze_and_resume() -> void:
 	_expect_true(not state.is_paused, "pause should disable on second toggle")
 	state.drain_fuel(25.0)
 	_expect_true(state.fuel < fuel_before_pause, "fuel should drain again after unpausing")
+
+func _test_main_loop_advances_respawn_after_crash() -> void:
+	var main = MainScript.new()
+	var player = PlayerShipScript.new()
+	var hud := Control.new()
+	hud.size = Vector2(320.0, 96.0)
+	var input_debug := Label.new()
+	input_debug.visible = false
+	main.set("player", player)
+	main.set("hud", hud)
+	main.set("input_label", input_debug)
+	main.call("_ensure_fullscreen_input_action")
+	var state = main.get("game_state")
+	state.start_run()
+	state.die()
+	_expect_true(not state.is_alive, "main scene should reflect death before respawn")
+	main.call("_process", state.respawn_cooldown + 0.05)
+	_expect_true(state.is_alive, "main loop should advance respawn cooldown after a crash")
+	player.free()
+	hud.free()
+	input_debug.free()
+	main.free()


### PR DESCRIPTION
## Summary
- cache terrain, ceiling, and parallax config so redraws stop rebuilding arrays and dictionaries every frame
- replace repeated group scans and dynamic layer dispatch with tracked actor registries, pooled SFX players, and lighter HUD refreshes
- fix the respawn freeze after a crash and add regression coverage for the main loop death-to-respawn path

## Testing
- `/Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/chrisbremer/code/starkiller-space-game/.worktrees/performance-respawn-pass --user-data-dir /tmp/starkiller-pr-boot --log-file /tmp/starkiller-pr-boot/boot.log --quit`
- `/Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/chrisbremer/code/starkiller-space-game/.worktrees/performance-respawn-pass --user-data-dir /tmp/starkiller-pr-tests --log-file /tmp/starkiller-pr-tests/tests.log --script res://tests/run_tests.gd`